### PR TITLE
Improvement use hapi request decoration

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,11 +58,13 @@ server.route({
 });
 ```
 
-## Plugin Options
+## Options
+
+The plugin provides the following options:
 
 | Option    | Default     | Description |
 |-----------|-------------|-------------|
 | `locales` | `[]`        | Your list of supported locales, e.g., `['de', 'en']` or `['en-US', 'es-ES']`. |
 | `query`   | `locale`    | Name of query parameter to evaluate. Set to `false` to switch off. |
-| `param`   | `locale`    | Name of path parameter to evaluate. Set to `false` to switch off. |
+| `path`    | `locale`    | Name of path parameter to evaluate. Set to `false` to switch off. |
 | `method`  | `getLocale` | Name of method for request decoration, i.e., `request.getLocale()`. |

--- a/README.md
+++ b/README.md
@@ -2,15 +2,17 @@
 
 Locale and language detection for Hapi Server v17.
 
-Evaluates locale information from `accept-language` header and query parameter
-and decorates Hapi request object with `request.getLocale()`
-available in all route handlers.
+Evaluates locale information from `accept-language` header and query or path parameter.
+Decorates Hapi request object with `request.getLocale()` available in all route handlers.
 
-If a `locale` query parameter is provided, it has highest priority.
-Second priority is the `accept-language` http request header.
-Final priority is a fallback locale.
+Priority of evaluation:
+(1) `locale` query parameter (if provided),
+(2) `locale` path parameter (if provided),
+(3) `accept-language` http request header,
+(4) fallback locale (the first locale in `locales` list).
 
-Method `request.getLocale()` and query parameter `locale` can be renamed.
+Decorated method `request.getLocale()` can be renamed.
+Query and path parameters `locale` can be renamed or switched off.
 
 ## Install
 
@@ -18,7 +20,7 @@ Method `request.getLocale()` and query parameter `locale` can be renamed.
 npm install --save hapi-locale-17
 ```
 
-## Example
+## Usage
 
 Register the plugin with Hapi server like this:
 
@@ -35,8 +37,6 @@ const provision = async () => {
     plugin: HapiLocale,
     options: {
       locales: ['de', 'en'], // your supported locales
-      query: 'lang',         // name of query param, defaults to 'locale'
-      method: 'getLang',     // name of method, defaults to 'getLocale'
     }
   });
   await server.start();
@@ -57,3 +57,12 @@ server.route({
   }
 });
 ```
+
+## Plugin Options
+
+| Option    | Default     | Description |
+|-----------|-------------|-------------|
+| `locales` | `[]`        | Your list of supported locales, e.g., `['de', 'en']` or `['en-US', 'es-ES']`. |
+| `query`   | `locale`    | Name of query parameter to evaluate. Set to `false` to switch off. |
+| `param`   | `locale`    | Name of path parameter to evaluate. Set to `false` to switch off. |
+| `method`  | `getLocale` | Name of method for request decoration, i.e., `request.getLocale()`. |

--- a/README.md
+++ b/README.md
@@ -2,11 +2,15 @@
 
 Locale and language detection for Hapi Server v17.
 
-Evaluates locale information from `accept-language` header and query parameter and attaches locale to `request.locale` available in all Hapi route handlers.
+Evaluates locale information from `accept-language` header and query parameter
+and decorates Hapi request object with `request.getLocale()`
+available in all route handlers.
 
-If a `locale` query parameter is provided, it has highest priority. Second priority is the `accept-language` http request header. Final priority is a fallback locale.
+If a `locale` query parameter is provided, it has highest priority.
+Second priority is the `accept-language` http request header.
+Final priority is a fallback locale.
 
-Target attribute `request.locale` and query parameter `locale` can be renamed.
+Method `request.getLocale()` and query parameter `locale` can be renamed.
 
 ## Install
 
@@ -15,6 +19,8 @@ npm install --save hapi-locale-17
 ```
 
 ## Example
+
+Register the plugin with Hapi server like this:
 
 ```js
 const Hapi = require('hapi');
@@ -30,11 +36,24 @@ const provision = async () => {
     options: {
       locales: ['de', 'en'], // your supported locales
       query: 'lang',         // name of query param, defaults to 'locale'
-      attribute: 'lang',     // name of target attribute, defaults to 'locale'
+      method: 'getLang',     // name of method, defaults to 'getLocale'
     }
   });
   await server.start();
 };
 
 provision();
+```
+
+In your route handler, do something like this:
+
+```js
+server.route({
+  method: 'GET',
+  path: '/test',
+  handler: function (request, h) {
+    const locale = request.getLocale();
+    // ...
+  }
+});
 ```

--- a/package.json
+++ b/package.json
@@ -13,12 +13,12 @@
     "hapi",
     "i18n",
     "l10n",
-    "langauge",
+    "language",
     "locale"
   ],
   "scripts": {
     "lint": "eslint . --ignore-path ./.eslintignore",
-    "test": "NODE_ENV=test istanbul cover _mocha -- --recursive --timeout 5000 test",
+    "test": "NODE_ENV=test istanbul cover _mocha -- --recursive test",
     "preversion": "npm run lint && npm test"
   },
   "engines": {
@@ -34,12 +34,10 @@
     "eslint-plugin-should-promised": "^2.0.0",
     "hapi": "^17.1.1",
     "istanbul": "^0.4.5",
-    "mocha": "^4.0.1",
-    "sinon": "^4.1.3",
-    "sinon-chai": "^2.14.0"
+    "mocha": "^4.0.1"
   },
   "dependencies": {
     "accept-language-parser": "^1.4.1",
-    "rind-locale": "0.0.3"
+    "rind-locale": "~0.0.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hapi-locale-17",
-  "version": "1.0.2",
+  "version": "2.0.0",
   "description": "Locale and language detection for Hapi v17",
   "main": "src/index.js",
   "author": "Frank Thelen",

--- a/src/index.js
+++ b/src/index.js
@@ -6,7 +6,7 @@ const register = (server, {
   locales = [],
   fallback = locales[0],
   query = 'locale',
-  param = 'locale',
+  path = 'locale',
   method = 'getLocale',
 }) => {
   server.decorate('request', method, function f() {
@@ -16,9 +16,9 @@ const register = (server, {
       if (queryValue) {
         return matcher({ locales })(queryValue) || fallback;
       }
-      const paramValue = param ? request.params[param] : false;
-      if (paramValue) {
-        return matcher({ locales })(paramValue) || fallback;
+      const pathValue = path ? request.params[path] : false;
+      if (pathValue) {
+        return matcher({ locales })(pathValue) || fallback;
       }
       const headerValue = request.headers['accept-language'];
       if (headerValue) {

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -13,19 +13,25 @@ async function setup(options = {}) {
   const server = new Hapi.Server({
     port: 9001,
   });
-  const test = {
+  const route1 = {
     method: 'GET',
     path: '/test',
     handler: () => 'ok',
   };
-  const test2 = {
+  const route2 = {
     method: 'GET',
     path: '/media/{locale}',
     handler: () => 'ok',
   };
+  const route3 = {
+    method: 'GET',
+    path: '/media2/{lang}',
+    handler: () => 'ok',
+  };
   await server.register({ plugin: locale, options });
-  await server.route(test);
-  await server.route(test2);
+  await server.route(route1);
+  await server.route(route2);
+  await server.route(route3);
   await server.start();
   return server;
 }
@@ -144,6 +150,7 @@ describe('hapi-locale-17 with `query` option', async () => {
     server = await setup({
       locales: ['de', 'en'],
       query: 'lang',
+      path: false,
       method: 'getLang',
     });
   });
@@ -152,10 +159,40 @@ describe('hapi-locale-17 with `query` option', async () => {
     server.stop();
   });
 
-  it('should accept user-defined query param', () => {
+  it('should accept user-defined query param `lang`', () => {
     return server
       .inject({
         url: '/test?lang=de',
+        headers: {
+          'Accept-Language': 'en-GB;q=0.8,en-US;q=0.7,en;q=0.6',
+        },
+      })
+      .should.be.fulfilled.then((response) => {
+        expect(response.request.getLang()).to.be.equal('de');
+      });
+  });
+});
+
+describe('hapi-locale-17 with `path` option', async () => {
+  let server;
+
+  before(async () => {
+    server = await setup({
+      locales: ['de', 'en'],
+      query: false,
+      path: 'lang',
+      method: 'getLang',
+    });
+  });
+
+  after(async () => {
+    server.stop();
+  });
+
+  it('should accept user-defined path param `lang`', () => {
+    return server
+      .inject({
+        url: '/media2/de',
         headers: {
           'Accept-Language': 'en-GB;q=0.8,en-US;q=0.7,en;q=0.6',
         },

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -18,8 +18,14 @@ async function setup(options = {}) {
     path: '/test',
     handler: () => 'ok',
   };
+  const test2 = {
+    method: 'GET',
+    path: '/media/{locale}',
+    handler: () => 'ok',
+  };
   await server.register({ plugin: locale, options });
   await server.route(test);
+  await server.route(test2);
   await server.start();
   return server;
 }
@@ -37,7 +43,7 @@ describe('hapi-locale-17 with `locales` option', async () => {
     server.stop();
   });
 
-  it('should add `locale` to request with supported `de`', () => {
+  it('should provide `request.getLocale()` with supported `de`', () => {
     return server
       .inject({
         url: '/test',
@@ -50,7 +56,7 @@ describe('hapi-locale-17 with `locales` option', async () => {
       });
   });
 
-  it('should add `locale` to request with supported `de` / query param', () => {
+  it('should provide `request.getLocale()` with supported `de` / query param', () => {
     return server
       .inject({
         url: '/test?locale=de',
@@ -63,10 +69,36 @@ describe('hapi-locale-17 with `locales` option', async () => {
       });
   });
 
-  it('should add `locale` to request with default `es` / query param with unsupported locale', () => {
+  it('should provide `request.getLocale()` with supported `de` / path param', () => {
+    return server
+      .inject({
+        url: '/media/de',
+        headers: {
+          'Accept-Language': 'en-GB;q=0.8,en-US;q=0.7,en;q=0.6',
+        },
+      })
+      .should.be.fulfilled.then((response) => {
+        expect(response.request.getLocale()).to.be.equal('de');
+      });
+  });
+
+  it('should provide `request.getLocale()` with default `es` / query param with unsupported locale', () => {
     return server
       .inject({
         url: '/test?locale=tr',
+        headers: {
+          'Accept-Language': 'q=0.9,en-GB;q=0.8,en-US;q=0.7,en;q=0.6',
+        },
+      })
+      .should.be.fulfilled.then((response) => {
+        expect(response.request.getLocale()).to.be.equal('es');
+      });
+  });
+
+  it('should provide `request.getLocale()` with default `es` / path param with unsupported locale', () => {
+    return server
+      .inject({
+        url: '/media/tr',
         headers: {
           'Accept-Language': 'q=0.9,en-GB;q=0.8,en-US;q=0.7,en;q=0.6',
         },
@@ -91,7 +123,7 @@ describe('hapi-locale-17 with `method` option', async () => {
     server.stop();
   });
 
-  it('should add user-defined method', () => {
+  it('should provide user-defined `request.getLang()`', () => {
     return server
       .inject({
         url: '/test',


### PR DESCRIPTION
replace `request.locale` with `request.getLocale()` // internally use Hapi `server.decorate()` rather than `server.ext()`